### PR TITLE
Bumped actions/setup-java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ Thumbs.db
 # Ignore built ts files
 __tests__/runner/*
 lib/**/*
+
+# Intellij project settings
+*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
           command: mvn clean verify
 ```
 
-### Manual Usage
+### Running the Command Separately
 
 ```yaml
 # ...

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
           apikey: ${{ secrets.THUNDRA_APIKEY }}
           project_id: ${{ secrets.THUNDRA_PROJECT_ID }}
       - name: Run mvn command
-        run: mvn clean install
+        run: mvn clean verify
 ```
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -15,18 +15,22 @@ Once you get the Thundra API Key, make sure to set it as a secret. A sample Gith
 ```yaml
 # ...
 
-steps:
-  - uses: actions/checkout@v2
-  - name: Set up JDK 1.8
-    uses: actions/setup-java@v1
-    with:
-      java-version: 1.8
-  - name: Thundra Maven Test Instrumentation
-    uses: thundra-io/thundra-maven-test-action@v1
-    with:
-      apikey: ${{ secrets.THUNDRA_APIKEY }}
-      project_id: ${{ secrets.THUNDRA_PROJECT_ID }}
-      command: mvn clean install
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest      
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '8'
+      - name: Thundra Maven Test Instrumentation
+        uses: thundra-io/thundra-maven-test-action@v1
+        with:
+          apikey: ${{ secrets.THUNDRA_APIKEY }}
+          project_id: ${{ secrets.THUNDRA_PROJECT_ID }}
+          command: mvn clean verify
 ```
 
 ### Manual Usage
@@ -34,19 +38,23 @@ steps:
 ```yaml
 # ...
 
-steps:
-  - uses: actions/checkout@v2
-  - name: Set up JDK 1.8
-    uses: actions/setup-java@v1
-    with:
-      java-version: 1.8
-  - name: Thundra Maven Test Instrumentation
-    uses: thundra-io/thundra-maven-test-action@v1
-    with:
-      apikey: ${{ secrets.THUNDRA_APIKEY }}
-      project_id: ${{ secrets.THUNDRA_PROJECT_ID }}
-  - name: Run mvn command
-    run: mvn clean install
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '8'
+      - name: Thundra Maven Test Instrumentation
+        uses: thundra-io/thundra-maven-test-action@v1
+        with:
+          apikey: ${{ secrets.THUNDRA_APIKEY }}
+          project_id: ${{ secrets.THUNDRA_PROJECT_ID }}
+      - name: Run mvn command
+        run: mvn clean install
 ```
 
 ## Known Issues


### PR DESCRIPTION
This PR bumpes the github action for setup-java, see here for the latest changes and usage: https://github.com/actions/setup-java

Next to that the example has slightly been adjusted so it will be easier to copy-paste it into the project of the end-user.